### PR TITLE
Fix some tiny issues

### DIFF
--- a/mods/yr/rules/allied-structures.yaml
+++ b/mods/yr/rules/allied-structures.yaml
@@ -985,7 +985,7 @@ gaweat:
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 90
-		Prerequisites: gatech, ~structures.allies
+		Prerequisites: gatech, ~structures.allies, ~techlevel.unrestricted
 		BuildLimit: 1
 		Description: Play God with deadly weather!
 	Selectable:
@@ -1050,7 +1050,7 @@ gacsph:
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 80
-		Prerequisites: gatech, ~structures.allies
+		Prerequisites: gatech, ~structures.allies, ~techlevel.unrestricted
 		Description: Allows teleporting units in a 3x3 array.
 		BuildLimit: 1
 	Selectable:

--- a/mods/yr/sequences/tech-structures.yaml
+++ b/mods/yr/sequences/tech-structures.yaml
@@ -1,4 +1,5 @@
 caoild:
+    Inherits: ^TechStructure
 	Defaults:
 		UseTilesetCode: true
 	idle:


### PR DESCRIPTION
Fix some tiny issues:
1. `caoild` missed the sequence `rubble`. Which would make game crash when there is a `caoild` destroyed on map.
2. `no superweapons` option not works to allied's `gaweat` and `gacsph`.