### PR TITLE
Fix #157 make allied/soviet's superweapon unable to capture

### DIFF
--- a/mods/yr/rules/allied-structures.yaml
+++ b/mods/yr/rules/allied-structures.yaml
@@ -980,7 +980,7 @@ gagap:
 		RequiredForShortGame: false
 
 gaweat:
-	Inherits: ^Building
+	Inherits: ^SupportBuilding
 	Inherits@shape: ^3x3Shape
 	Buildable:
 		Queue: Support

--- a/mods/yr/rules/soviet-structures.yaml
+++ b/mods/yr/rules/soviet-structures.yaml
@@ -731,7 +731,7 @@ nairon:
 		ValidPowerStates: Low, Critical
 
 namisl:
-	Inherits: ^Building
+	Inherits: ^SupportBuilding
 	Inherits@shape: ^3x3Shape
 	Buildable:
 		Queue: Support


### PR DESCRIPTION
Fix #157

Modifed super-weapons' inherits.

Make allied/soviet's superweapon unable to capture.